### PR TITLE
Исправлено неправильное отображение поля "Описание"

### DIFF
--- a/TimetableOfClasses/Ministry.Designer.cs
+++ b/TimetableOfClasses/Ministry.Designer.cs
@@ -42,13 +42,14 @@
 			this.DG_Ministry.AllowUserToAddRows = false;
 			this.DG_Ministry.AllowUserToDeleteRows = false;
 			this.DG_Ministry.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-			| System.Windows.Forms.AnchorStyles.Left) 
-			| System.Windows.Forms.AnchorStyles.Right)));
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.DG_Ministry.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
 			this.DG_Ministry.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
 			this.DG_Ministry.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-			this.Kod,
-			this.Naim,
-			this.Description});
+            this.Kod,
+            this.Naim,
+            this.Description});
 			this.DG_Ministry.Location = new System.Drawing.Point(12, 12);
 			this.DG_Ministry.Name = "DG_Ministry";
 			this.DG_Ministry.ReadOnly = true;
@@ -77,27 +78,21 @@
 			// 
 			// Kod
 			// 
-			this.Kod.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
 			this.Kod.HeaderText = "Код";
 			this.Kod.Name = "Kod";
 			this.Kod.ReadOnly = true;
-			this.Kod.Width = 51;
 			// 
 			// Naim
 			// 
-			this.Naim.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
 			this.Naim.HeaderText = "Наименование";
 			this.Naim.Name = "Naim";
 			this.Naim.ReadOnly = true;
-			this.Naim.Width = 205;
 			// 
 			// Description
 			// 
-			this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
 			this.Description.HeaderText = "Описание";
 			this.Description.Name = "Description";
 			this.Description.ReadOnly = true;
-			this.Description.Width = 263;
 			// 
 			// Ministry
 			// 
@@ -122,5 +117,5 @@
 		private System.Windows.Forms.DataGridViewTextBoxColumn Kod;
 		private System.Windows.Forms.DataGridViewTextBoxColumn Naim;
 		private System.Windows.Forms.DataGridViewTextBoxColumn Description;
-    }
+	}
 }

--- a/TimetableOfClasses/Ministry.Designer.cs
+++ b/TimetableOfClasses/Ministry.Designer.cs
@@ -28,87 +28,89 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.DG_Ministry = new System.Windows.Forms.DataGridView();
-			this.Add = new System.Windows.Forms.Button();
-			this.Delete = new System.Windows.Forms.Button();
-			this.Kod = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.Naim = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// DG_Ministry
-			// 
-			this.DG_Ministry.AllowUserToAddRows = false;
-			this.DG_Ministry.AllowUserToDeleteRows = false;
-			this.DG_Ministry.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.DG_Ministry = new System.Windows.Forms.DataGridView();
+            this.Add = new System.Windows.Forms.Button();
+            this.Delete = new System.Windows.Forms.Button();
+            this.Kod = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Naim = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // DG_Ministry
+            // 
+            this.DG_Ministry.AllowUserToAddRows = false;
+            this.DG_Ministry.AllowUserToDeleteRows = false;
+            this.DG_Ministry.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.DG_Ministry.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-			this.DG_Ministry.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.DG_Ministry.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.DG_Ministry.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Kod,
             this.Naim,
             this.Description});
-			this.DG_Ministry.Location = new System.Drawing.Point(12, 12);
-			this.DG_Ministry.Name = "DG_Ministry";
-			this.DG_Ministry.ReadOnly = true;
-			this.DG_Ministry.Size = new System.Drawing.Size(562, 215);
-			this.DG_Ministry.TabIndex = 1;
-			// 
-			// Add
-			// 
-			this.Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.Add.Location = new System.Drawing.Point(499, 233);
-			this.Add.Name = "Add";
-			this.Add.Size = new System.Drawing.Size(75, 23);
-			this.Add.TabIndex = 4;
-			this.Add.Text = "Добавить";
-			this.Add.UseVisualStyleBackColor = true;
-			// 
-			// Delete
-			// 
-			this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.Delete.Location = new System.Drawing.Point(418, 233);
-			this.Delete.Name = "Delete";
-			this.Delete.Size = new System.Drawing.Size(75, 23);
-			this.Delete.TabIndex = 3;
-			this.Delete.Text = "Удалить";
-			this.Delete.UseVisualStyleBackColor = true;
-			// 
-			// Kod
-			// 
-			this.Kod.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-			this.Kod.HeaderText = "Код";
-			this.Kod.Name = "Kod";
-			this.Kod.ReadOnly = true;
-			this.Kod.Width = 51;
-			// 
-			// Naim
-			// 
-			this.Naim.HeaderText = "Наименование";
-			this.Naim.Name = "Naim";
-			this.Naim.ReadOnly = true;
-			this.Naim.Width = 205;
-			// 
-			// Description
-			// 
-			this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-			this.Description.HeaderText = "Описание";
-			this.Description.Name = "Description";
-			this.Description.ReadOnly = true;
-			// 
-			// Ministry
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(586, 268);
-			this.Controls.Add(this.Add);
-			this.Controls.Add(this.Delete);
-			this.Controls.Add(this.DG_Ministry);
-			this.Name = "Ministry";
-			this.Text = "Министерства";
-			((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).EndInit();
-			this.ResumeLayout(false);
+            this.DG_Ministry.Location = new System.Drawing.Point(12, 12);
+            this.DG_Ministry.Name = "DG_Ministry";
+            this.DG_Ministry.ReadOnly = true;
+            this.DG_Ministry.Size = new System.Drawing.Size(562, 215);
+            this.DG_Ministry.TabIndex = 1;
+            // 
+            // Add
+            // 
+            this.Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.Add.Location = new System.Drawing.Point(499, 233);
+            this.Add.Name = "Add";
+            this.Add.Size = new System.Drawing.Size(75, 23);
+            this.Add.TabIndex = 4;
+            this.Add.Text = "Добавить";
+            this.Add.UseVisualStyleBackColor = true;
+            // 
+            // Delete
+            // 
+            this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.Delete.Location = new System.Drawing.Point(418, 233);
+            this.Delete.Name = "Delete";
+            this.Delete.Size = new System.Drawing.Size(75, 23);
+            this.Delete.TabIndex = 3;
+            this.Delete.Text = "Удалить";
+            this.Delete.UseVisualStyleBackColor = true;
+            // 
+            // Kod
+            // 
+            this.Kod.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Kod.HeaderText = "Код";
+            this.Kod.Name = "Kod";
+            this.Kod.ReadOnly = true;
+            this.Kod.Width = 51;
+            // 
+            // Naim
+            // 
+            this.Naim.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Naim.HeaderText = "Наименование";
+            this.Naim.Name = "Naim";
+            this.Naim.ReadOnly = true;
+            this.Naim.Width = 205;
+            // 
+            // Description
+            // 
+            this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Description.HeaderText = "Описание";
+            this.Description.Name = "Description";
+            this.Description.ReadOnly = true;
+            this.Description.Width = 263;
+            // 
+            // Ministry
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(586, 268);
+            this.Controls.Add(this.Add);
+            this.Controls.Add(this.Delete);
+            this.Controls.Add(this.DG_Ministry);
+            this.Name = "Ministry";
+            this.Text = "Министерства";
+            ((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).EndInit();
+            this.ResumeLayout(false);
 
         }
 
@@ -117,8 +119,8 @@
 		private System.Windows.Forms.DataGridView DG_Ministry;
 		private System.Windows.Forms.Button Add;
 		private System.Windows.Forms.Button Delete;
-		private System.Windows.Forms.DataGridViewTextBoxColumn Kod;
-		private System.Windows.Forms.DataGridViewTextBoxColumn Naim;
-		private System.Windows.Forms.DataGridViewTextBoxColumn Description;
-	}
+        private System.Windows.Forms.DataGridViewTextBoxColumn Kod;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Naim;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Description;
+    }
 }

--- a/TimetableOfClasses/Ministry.Designer.cs
+++ b/TimetableOfClasses/Ministry.Designer.cs
@@ -28,89 +28,89 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.DG_Ministry = new System.Windows.Forms.DataGridView();
-            this.Add = new System.Windows.Forms.Button();
-            this.Delete = new System.Windows.Forms.Button();
-            this.Kod = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Naim = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            ((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // DG_Ministry
-            // 
-            this.DG_Ministry.AllowUserToAddRows = false;
-            this.DG_Ministry.AllowUserToDeleteRows = false;
-            this.DG_Ministry.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.DG_Ministry.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.DG_Ministry.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Kod,
-            this.Naim,
-            this.Description});
-            this.DG_Ministry.Location = new System.Drawing.Point(12, 12);
-            this.DG_Ministry.Name = "DG_Ministry";
-            this.DG_Ministry.ReadOnly = true;
-            this.DG_Ministry.Size = new System.Drawing.Size(562, 215);
-            this.DG_Ministry.TabIndex = 1;
-            // 
-            // Add
-            // 
-            this.Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.Add.Location = new System.Drawing.Point(499, 233);
-            this.Add.Name = "Add";
-            this.Add.Size = new System.Drawing.Size(75, 23);
-            this.Add.TabIndex = 4;
-            this.Add.Text = "Добавить";
-            this.Add.UseVisualStyleBackColor = true;
-            // 
-            // Delete
-            // 
-            this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.Delete.Location = new System.Drawing.Point(418, 233);
-            this.Delete.Name = "Delete";
-            this.Delete.Size = new System.Drawing.Size(75, 23);
-            this.Delete.TabIndex = 3;
-            this.Delete.Text = "Удалить";
-            this.Delete.UseVisualStyleBackColor = true;
-            // 
-            // Kod
-            // 
-            this.Kod.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Kod.HeaderText = "Код";
-            this.Kod.Name = "Kod";
-            this.Kod.ReadOnly = true;
-            this.Kod.Width = 51;
-            // 
-            // Naim
-            // 
-            this.Naim.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Naim.HeaderText = "Наименование";
-            this.Naim.Name = "Naim";
-            this.Naim.ReadOnly = true;
-            this.Naim.Width = 205;
-            // 
-            // Description
-            // 
-            this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Description.HeaderText = "Описание";
-            this.Description.Name = "Description";
-            this.Description.ReadOnly = true;
-            this.Description.Width = 263;
-            // 
-            // Ministry
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(586, 268);
-            this.Controls.Add(this.Add);
-            this.Controls.Add(this.Delete);
-            this.Controls.Add(this.DG_Ministry);
-            this.Name = "Ministry";
-            this.Text = "Министерства";
-            ((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).EndInit();
-            this.ResumeLayout(false);
+			this.DG_Ministry = new System.Windows.Forms.DataGridView();
+			this.Add = new System.Windows.Forms.Button();
+			this.Delete = new System.Windows.Forms.Button();
+			this.Kod = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			this.Naim = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// DG_Ministry
+			// 
+			this.DG_Ministry.AllowUserToAddRows = false;
+			this.DG_Ministry.AllowUserToDeleteRows = false;
+			this.DG_Ministry.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			| System.Windows.Forms.AnchorStyles.Left) 
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.DG_Ministry.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+			this.DG_Ministry.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+			this.Kod,
+			this.Naim,
+			this.Description});
+			this.DG_Ministry.Location = new System.Drawing.Point(12, 12);
+			this.DG_Ministry.Name = "DG_Ministry";
+			this.DG_Ministry.ReadOnly = true;
+			this.DG_Ministry.Size = new System.Drawing.Size(562, 215);
+			this.DG_Ministry.TabIndex = 1;
+			// 
+			// Add
+			// 
+			this.Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.Add.Location = new System.Drawing.Point(499, 233);
+			this.Add.Name = "Add";
+			this.Add.Size = new System.Drawing.Size(75, 23);
+			this.Add.TabIndex = 4;
+			this.Add.Text = "Добавить";
+			this.Add.UseVisualStyleBackColor = true;
+			// 
+			// Delete
+			// 
+			this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.Delete.Location = new System.Drawing.Point(418, 233);
+			this.Delete.Name = "Delete";
+			this.Delete.Size = new System.Drawing.Size(75, 23);
+			this.Delete.TabIndex = 3;
+			this.Delete.Text = "Удалить";
+			this.Delete.UseVisualStyleBackColor = true;
+			// 
+			// Kod
+			// 
+			this.Kod.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+			this.Kod.HeaderText = "Код";
+			this.Kod.Name = "Kod";
+			this.Kod.ReadOnly = true;
+			this.Kod.Width = 51;
+			// 
+			// Naim
+			// 
+			this.Naim.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+			this.Naim.HeaderText = "Наименование";
+			this.Naim.Name = "Naim";
+			this.Naim.ReadOnly = true;
+			this.Naim.Width = 205;
+			// 
+			// Description
+			// 
+			this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+			this.Description.HeaderText = "Описание";
+			this.Description.Name = "Description";
+			this.Description.ReadOnly = true;
+			this.Description.Width = 263;
+			// 
+			// Ministry
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(586, 268);
+			this.Controls.Add(this.Add);
+			this.Controls.Add(this.Delete);
+			this.Controls.Add(this.DG_Ministry);
+			this.Name = "Ministry";
+			this.Text = "Министерства";
+			((System.ComponentModel.ISupportInitialize)(this.DG_Ministry)).EndInit();
+			this.ResumeLayout(false);
 
         }
 
@@ -119,8 +119,8 @@
 		private System.Windows.Forms.DataGridView DG_Ministry;
 		private System.Windows.Forms.Button Add;
 		private System.Windows.Forms.Button Delete;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Kod;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Naim;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Description;
+		private System.Windows.Forms.DataGridViewTextBoxColumn Kod;
+		private System.Windows.Forms.DataGridViewTextBoxColumn Naim;
+		private System.Windows.Forms.DataGridViewTextBoxColumn Description;
     }
 }


### PR DESCRIPTION
#244
Итоговый результат:
При перемещении каретки, которая находится внизу в право до упора поле "Описание" отображается так, что можно прочитать название поля.

![Ministry](https://user-images.githubusercontent.com/47635274/58436409-e4653600-80cd-11e9-9795-dc48ddcc79d1.png)