### PR TITLE
Перенос инкремента

### DIFF
--- a/UnitTestOfTimetableOfClasses/UT_Delete_CGroup.cs
+++ b/UnitTestOfTimetableOfClasses/UT_Delete_CGroup.cs
@@ -20,8 +20,7 @@ namespace UnitTestOfTimetableOfClasses
             Assert.AreEqual(countRows+1, refData.CGroup.Rows.Count);
             do
             {
-                Console.WriteLine(i);
-                i++;
+                Console.WriteLine(i++);
             }
             while ((refData.CGroup.Rows[countRows]) !=(refData.CGroup.Rows[i]));
             Assert.AreEqual(refData.CGroup.Rows[countRows], refData.CGroup.Rows[i]);


### PR DESCRIPTION
Теперь **инкремент** находится сразу в строке вывода, что оптимизирует работу цикла.