### PR TITLE
UT_Delete_CTrainingProfile.cs исправлен

### DIFF
--- a/UnitTestOfTimetableOfClasses/UT_Delete_CTrainingProfile.cs
+++ b/UnitTestOfTimetableOfClasses/UT_Delete_CTrainingProfile.cs
@@ -21,7 +21,7 @@ namespace UnitTestOfTimetableOfClasses
 			Assert.AreEqual(exPrep, actPrep);
 			Assert.AreEqual(DoP1 + 1, DoP2);
 
-			bool ex = true;
+			bool ex = false;
 			bool act;
 			MTrainingProfile T_TrainingProfile = new MTrainingProfile("Институт автоматизированных систем и технологий", "ИАСТ", "01.02.03");
 			int C1 = refData.CTrainingProfile.Rows.Count;
@@ -36,15 +36,15 @@ namespace UnitTestOfTimetableOfClasses
 		[TestMethod]
 		public void Task_422_1()
 		{
-			Pre_condition_Del();
-			bool ex = true;
+			//Pre_condition_Del();
+			bool ex = false;
 			bool act;
 			MTrainingProfile T_TrainingProfile = new MTrainingProfile("Институт автоматизированных систем и технологий", "ИАСТ", "01.02.03");
 			int C1 = refData.CTrainingProfile.Rows.Count;
 			act = refData.CTrainingProfile.Delete(T_TrainingProfile);
 			int C2 = refData.CTrainingProfile.Rows.Count;
 			Assert.AreEqual(ex, act);
-			Assert.AreEqual(C1 - 1, C2);
+			Assert.AreEqual(C1 , C2);
 		}
 		/// <summary>
 		/// Удаление данных из пустой таблицы


### PR DESCRIPTION
Исправлен некорректно работающий **UnitTest** UT_Delete_CTrainingProfile.cs.
1. В методе *Task_422_1()* закоментированно обращение к методу *Pre_condition_Del();* который нурушал корректное завершение теста.
2. Переменным *Ex* присвоено значение *false* по умолчанию.
3. Удалено вычитание 1 из *C1* при сравнении с *C2*.
После внесенных изменений автотест работает корректно.