### PR TITLE
Fixes #1445 Рефакторинг кода

### DIFF
--- a/UnitTestOfTimetableOfClasses/UT_CAcademicDegree/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CAcademicDegree/UT_Update/UnitTest.cs
@@ -44,7 +44,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CAcademicDegree.UT_Update
 
             //assert
             Assert.AreEqual(ex, act);
-
         }
         /// <summary>
         /// Замена всех полей пустыми строками
@@ -64,7 +63,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CAcademicDegree.UT_Update
 
             //assert
             Assert.AreEqual(ex, act);
-
         }
     }
 }

--- a/UnitTestOfTimetableOfClasses/UT_CAcademicLoad/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CAcademicLoad/UT_Update/UnitTest.cs
@@ -43,7 +43,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CAcademicLoad.UT_Update
             MAcademicLoad PreMa = new MAcademicLoad(100, "17-ИСбо-2а", "Правоведение", "Иванов Иван Иванович", "Лекция", "20","к");
             bool actualPreMa = refData.CAcademicLoad.Insert(PreMa);
             Assert.AreEqual(true, actualPreMa, "Не удалось вставить нагрузку для " + PreMa.Group);
-
         }
         RefData refData = new RefData();
 
@@ -147,6 +146,5 @@ namespace UnitTestOfTimetableOfClasses.UT_CAcademicLoad.UT_Update
             bool actual = refData.CAcademicLoad.Update(PreMa);
             Assert.AreEqual(expected, actual, " Произошел ввод некорректных данных в атрибут тип занятия ");
         }
-
     }
 }

--- a/UnitTestOfTimetableOfClasses/UT_CGroup/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CGroup/UT_Update/UnitTest.cs
@@ -65,8 +65,7 @@ namespace UnitTestOfTimetableOfClasses.UT_CGroup.UT_Update
             Assert.IsTrue(refData.CGroup.Delete(gr1), "Не удалось удалить группу" + gr1.Group);
 
             Assert.IsTrue(refData.CTrainingProfile.Delete(mTrainingProfile), "Не удалось удалить профиль обучения");
-            Assert.IsTrue(refData.CDirectionOfPreparation.Delete(mDirection), "Не удалось удалить направление подготовки");
-           
+            Assert.IsTrue(refData.CDirectionOfPreparation.Delete(mDirection), "Не удалось удалить направление подготовки");          
         }
 
         /// <summary>
@@ -103,7 +102,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CGroup.UT_Update
 
             Assert.IsTrue(refData.CTrainingProfile.Delete(mTrainingProfile), "Не удалось удалить профиль обучения");
             Assert.IsTrue(refData.CDirectionOfPreparation.Delete(mDirection), "Не удалось удалить направление подготовки");
-
         }
  
         /// <summary>
@@ -139,7 +137,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CGroup.UT_Update
 
             Assert.IsTrue(refData.CTrainingProfile.Delete(mTrainingProfile), "Не удалось удалить профиль обучения");
             Assert.IsTrue(refData.CDirectionOfPreparation.Delete(mDirection), "Не удалось удалить направление подготовки");
-
         }
  
         /// <summary>
@@ -175,7 +172,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CGroup.UT_Update
 
             Assert.IsTrue(refData.CTrainingProfile.Delete(mTrainingProfile), "Не удалось удалить профиль обучения");
             Assert.IsTrue(refData.CDirectionOfPreparation.Delete(mDirection), "Не удалось удалить направление подготовки");
-
         }
 
         /// <summary>
@@ -213,7 +209,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CGroup.UT_Update
 
             Assert.IsTrue(refData.CTrainingProfile.Delete(mTrainingProfile), "Не удалось удалить профиль обучения");
             Assert.IsTrue(refData.CDirectionOfPreparation.Delete(mDirection), "Не удалось удалить направление подготовки");
-
         }
 
         /// <summary>
@@ -243,7 +238,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CGroup.UT_Update
 
             Assert.IsTrue(refData.CTrainingProfile.Delete(mTrainingProfile), "Не удалось удалить профиль обучения");
             Assert.IsTrue(refData.CDirectionOfPreparation.Delete(mDirection), "Не удалось удалить направление подготовки");
-
         }
     }
 }

--- a/UnitTestOfTimetableOfClasses/UT_CInstitute/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CInstitute/UT_Update/UnitTest.cs
@@ -19,7 +19,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
             bool result = refData.CInstitute.Update(T_Institute);
 
             Assert.IsFalse(result, "Ожидаем, что Модель не изменяется");
-
         }
 
         [TestMethod]
@@ -34,7 +33,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
             bool result = refData.CInstitute.Update(T_Institute);
 
             Assert.IsFalse(result, "Ожидаем, что Модель не изменяется");
-
         }
 
         [TestMethod]
@@ -49,7 +47,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
             bool result = refData.CInstitute.Update(T_Institute);
 
             Assert.IsFalse(result, "Ожидаем, что Модель не изменяется");
-
         }
 
         [TestMethod]
@@ -64,7 +61,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
             bool result = refData.CInstitute.Update(T_Institute);
 
             Assert.IsFalse(result, "Ожидаем, что Модель не изменяется");
-
         }
 
         [TestMethod]
@@ -79,7 +75,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
 
             bool result = refData.CInstitute.Update(T_Institute);
             Assert.IsFalse(result, "Ожидаем, что Модель не изменяется");
-
         }
     }
 }

--- a/UnitTestOfTimetableOfClasses/UT_CTeacher/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CTeacher/UT_Update/UnitTest.cs
@@ -38,8 +38,7 @@ namespace UnitTestOfTimetableOfClasses.UT_CTeacher.UT_Update
          
             bool actual = refData.CTeacher.Update(tcher1);
             //assert
-            Assert.IsFalse( actual, " Удалось Изменить сведения в пустой таблице");
-            
+            Assert.IsFalse( actual, " Удалось Изменить сведения в пустой таблице");  
         }
         /// <summary>
         /// Изменить несуществующего преподавателя
@@ -59,7 +58,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CTeacher.UT_Update
             bool actual = refData.CTeacher.Update(tcher1);
             //assert
             Assert.IsFalse(actual, "Удалось Изменить несуществующего преподавателя");
-
         }
         /// <summary>
         /// Ввод коректных данных, при условии, что они не дублируют данные других экземпляров
@@ -88,7 +86,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CTeacher.UT_Update
             Assert.AreEqual(expected, actual, "Ввод коректных данных, при условии, что они не дублируют данные других экземпляров не произошел");
             //clear data
             Assert.IsTrue(refData.CTeacher.Delete(tcher), "Не удалось удалить преподавателя"+ tcher.FirstName);
-    
         }
 
         /// <summary>

--- a/UnitTestOfTimetableOfClasses/UT_CTitle/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CTitle/UT_Update/UnitTest.cs
@@ -20,7 +20,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CTitle.UT_Update
             bool result = refData.CTitle.Update(T_Title);
             //assert
             Assert.IsFalse(result, "Ожидаем, что Модель изменится");
-
         }
 
         [TestMethod]

--- a/UnitTestOfTimetableOfClasses/UT_CUniversity/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CUniversity/UT_Update/UnitTest.cs
@@ -63,7 +63,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CUniversity.UT_Update
 
             result = refData.CUniversity.Delete(gr1);
             Assert.IsTrue(result);
-
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1445 Исправлены **A closing curly bracet must not be preceded by a blank line**

1.  В строчках кода *UnitTestOfTimetableOfClasses/UT_CGroup/UT_Update/UnitTest.cs*.
2.  В строчках кода *UnitTestOfTimetableOfClasses/UT_CUniversity/UT_Update/UnitTest.cs*.
3.  В строчках кода *UnitTestOfTimetableOfClasses/UT_CAcademicLoad/UT_Update/UnitTest.cs*.
4.  В строчках кода *UnitTestOfTimetableOfClasses/UT_CTeacher/UT_Update/UnitTest.cs*.
5.  В строчках кода *UnitTestOfTimetableOfClasses/UT_CInstitute/UT_Update/UnitTest.cs*.
6.  В строчках кода *UnitTestOfTimetableOfClasses/UT_CTitle/UT_Update/UnitTest.cs*.
7.  В строчках кода *UnitTestOfTimetableOfClasses/UT_CAcademicDegree/UT_Update/UnitTest.cs*.