### PR TITLE
Убрал пустые строки после открывающихся фигурных скобок.

### DIFF
--- a/UnitTestOfTimetableOfClasses/UT_CInstitute/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CInstitute/UT_Update/UnitTest.cs
@@ -10,7 +10,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
         [TestMethod]
         public void UCInstitute_1() //замена всех атрибутов
         {
-
             MInstitute T_Institute = new MInstitute("Институт автоматизированных систем и технологий", "ИАСТ", "Лустгартен Ю.Л.", "Костромской Государственный Университет");
 
             refData.CInstitute.Insert(T_Institute);
@@ -25,7 +24,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
         [TestMethod]
         public void UCInstitute_2() //замена атрибутов Полное название
         {
-
             MInstitute T_Institute = new MInstitute("Институт автоматизированных систем и технологий", "ИАСТ", "Лустгартен Ю.Л.", "Костромской Государственный Университет");
 
             refData.CInstitute.Insert(T_Institute);
@@ -40,7 +38,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
         [TestMethod]
         public void UCInstitute_3() //краткая запись института уже есть в таблице
         {
-
             MInstitute T_Institute = new MInstitute("Институт автоматизированных систем и технологий", "ИАСТ", "Лустгартен Ю.Л.", "Костромской Государственный Университет");
 
             refData.CInstitute.Insert(T_Institute);
@@ -55,7 +52,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
         [TestMethod]
         public void UCInstitute_4() //директор уже есть в таблице
         {
-
             MInstitute T_Institute = new MInstitute("Институт автоматизированных систем и технологий", "ИАСТ", "Лустгартен Ю.Л.", "Костромской Государственный Университет");
 
             refData.CInstitute.Insert(T_Institute);
@@ -70,7 +66,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Update
         [TestMethod]
         public void UCInstitute_5() //наименование ВУЗа уже есть в таблице
         {
-
             MInstitute T_Institute = new MInstitute("Институт автоматизированных систем и технологий", "ИАСТ", "Лустгартен Ю.Л.", "Костромской Государственный Университет");
 
             refData.CInstitute.Insert(T_Institute);

--- a/UnitTestOfTimetableOfClasses/UT_CTitle/UT_Update/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/UT_CTitle/UT_Update/UnitTest.cs
@@ -10,7 +10,6 @@ namespace UnitTestOfTimetableOfClasses.UT_CTitle.UT_Update
         [TestMethod]
         public void UCTitle_1()//изменение когда атрибуты не повторяются и код учебного звания изменить нельзя
         {
-
             MTitle T_Title = new MTitle("Проф.", "Профессор");
 
             refData.CTitle.Insert(T_Title);


### PR DESCRIPTION
1. Убрал пустые строки после открывающихся фигурных скобок в двух файлах : 
- UnitTestOfTimetableOfClasses\UT_CInstitute\UT_Update\UnitTest.cs
- UnitTestOfTimetableOfClasses\UT_CTitle\UT_Update\UnitTest.cs

Fixes #1447