### PR TITLE
Рефакторинг тестов

### DIFF
--- a/UnitTestOfTimetableOfClasses/MAcademicDegree/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/MAcademicDegree/UnitTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-
 namespace UnitTestOfTimetableOfClasses.UT_MAcademicDegree
 {
     [TestClass]
@@ -25,7 +24,6 @@ namespace UnitTestOfTimetableOfClasses.UT_MAcademicDegree
                 Assert.Fail(ex.Message);
             }
         }
-
 
         /// <summary>
         /// /// Проверка корректного ввода в поле Сокращённая запись уч. степени

--- a/UnitTestOfTimetableOfClasses/MAuditor/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/MAuditor/UnitTest.cs
@@ -4,7 +4,6 @@ using System;
 
 namespace UnitTestOfTimetableOfClasses.UT_MAuditor
 {
-
     [TestClass]
     public class UT_MAuditor
     {

--- a/UnitTestOfTimetableOfClasses/MGroup/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/MGroup/UnitTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-
 namespace UnitTestOfTimetableOfClasses.UT_MGroup
 {
     [TestClass]

--- a/UnitTestOfTimetableOfClasses/MTitle/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/MTitle/UnitTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-
 namespace UnitTestOfTimetableOfClasses.UT_MTitle
 {
     /// <summary>

--- a/UnitTestOfTimetableOfClasses/MUniversity/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/MUniversity/UnitTest.cs
@@ -139,4 +139,3 @@ namespace UnitTestOfTimetableOfClasses.UT_MUniversity
         }
     }
 }
-


### PR DESCRIPTION
Fixes #1448
## Убраны лишние строки из 
**Код не должен содержать несколько пустых строк подряд.**
 UnitTestOfTimetableOfClasses \ MGroup \ UnitTest.cs: 5
 UnitTestOfTimetableOfClasses \ MUniversity \ UnitTest.cs: 142
 UnitTestOfTimetableOfClasses \ MAcademicDegree \ UnitTest.cs: 30
 UnitTestOfTimetableOfClasses \ MAcademicDegree \ UnitTest.cs: 5
 UnitTestOfTimetableOfClasses \ MTitle \ UnitTest.cs: 5
**Код не должен содержать пустых строк в конце файла.**
 UnitTestOfTimetableOfClasses \ MUniversity \ UnitTest.cs: 142
**После открывающей фигурной скобки не должно быть пустой строки.**
 UnitTestOfTimetableOfClasses \ MAuditor \ UnitTest.cs: 6
 UnitTestOfTimetableOfClasses \ MAcademicDegree \ UnitTest.cs: 10