### PR TITLE
Удалены пустые строки в UnitTestOfTimetableOfClasses\CInstitute\Insert\UnitTest.cs

### DIFF
--- a/UnitTestOfTimetableOfClasses/CInstitute/Insert/UnitTest.cs
+++ b/UnitTestOfTimetableOfClasses/CInstitute/Insert/UnitTest.cs
@@ -1,8 +1,6 @@
 ﻿using LibOfTimetableOfClasses;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-
-
 namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Insert
 {
     [TestClass]
@@ -89,8 +87,4 @@ namespace UnitTestOfTimetableOfClasses.UT_CInstitute.UT_Insert
             Assert.AreEqual(C1, C2);
         }
     }
-
 }
-
-
-


### PR DESCRIPTION
*№1526-Fix 6 Style issues in **UnitTestOfTimetableOfClasses\CInstitute\Insert\UnitTest.cs***
Удалены пустые строки в файле 
>UnitTestOfTimetableOfClasses\CInstitute\Insert\UnitTest.cs