### PR TITLE
Исправление стилистических ошибок в коде файла.

### DIFF
--- a/LibOfTimetableOfClasses/CGroup.cs
+++ b/LibOfTimetableOfClasses/CGroup.cs
@@ -83,14 +83,12 @@ namespace LibOfTimetableOfClasses
         /// <param name="model">Модель, выбранной строки в таблице</param>
         /// <returns>Результат удаления переданной строки из CGroup</returns>
         public bool Delete(Model model)
-
         {
             MGroup mGroup = (MGroup)model;
             for (int i = 0; i < this.Rows.Count; i++)
             {
                 if ((string)this.Rows[i]["Group"] == mGroup.Group)
                 {
-
                     this.Rows[i].Delete();
 
                     return true;
@@ -111,7 +109,6 @@ namespace LibOfTimetableOfClasses
 
             try
             {
-
                 DataRow newRow = this.NewRow();
                 newRow["Group"] = mGroup.Group;
                 newRow["Semestr"] = mGroup.Semester;
@@ -131,7 +128,6 @@ namespace LibOfTimetableOfClasses
             }
         }
 
-
         /// <summary>
         /// Обновление свойств строки в таблице CGroup из переданной модели MGroup
         /// Поиск изменяемой строки CGroup осуществляется по полю "Group"
@@ -144,7 +140,6 @@ namespace LibOfTimetableOfClasses
 
             for (int i = 0; i < this.Rows.Count; i++)
             {
-
                 if (mGroup.Group == (string)this.Rows[i]["Group"])
                 {
                     try


### PR DESCRIPTION
## Список произведенных улучшений:
1. Удаление пустой строки, прешествовавшей фигурной скобке.
    * Файл [LibOfTimetableOfClasses\CGroup.cs - строка 87](https://www.codefactor.io/repository/github/students-of-the-city-of-kostroma/student-timetable/source/dev/LibOfTimetableOfClasses/CGroup.cs#L87).
2. Удалание пустой строки, после открывающейся фигурной скобки.
    * Файл  [LibOfTimetableOfClasses\CGroup.cs - строка 146](https://www.codefactor.io/repository/github/students-of-the-city-of-kostroma/student-timetable/source/dev/LibOfTimetableOfClasses/CGroup.cs#L146).
    * Файл  [LibOfTimetableOfClasses\CGroup.cs - строка 113](https://www.codefactor.io/repository/github/students-of-the-city-of-kostroma/student-timetable/source/dev/LibOfTimetableOfClasses/CGroup.cs#L113).
    * Файл  [LibOfTimetableOfClasses\CGroup.cs - строка 92](https://www.codefactor.io/repository/github/students-of-the-city-of-kostroma/student-timetable/source/dev/LibOfTimetableOfClasses/CGroup.cs#L92).
3. Удаление одной из двух друг за другом идущих пустых строк.
    * Файл  [LibOfTimetableOfClasses\CGroup.cs - строка 134](https://www.codefactor.io/repository/github/students-of-the-city-of-kostroma/student-timetable/source/dev/LibOfTimetableOfClasses/CGroup.cs#L134).